### PR TITLE
[#5] 찜목록 화면 구현

### DIFF
--- a/src/apis/wish.ts
+++ b/src/apis/wish.ts
@@ -1,3 +1,14 @@
+import type { Exhibition } from '@/types/exhibition-type';
+
+export async function getWishes(): Promise<Array<Exhibition>> {
+  const response = await fetch('/user/me/wishes', { method: 'GET' });
+
+  if (!response.ok) throw new Error('GET /user/me/wishes');
+  const wishes = response.json();
+
+  return wishes;
+}
+
 export async function addWish(exhibitionId: number): Promise<{ exhibitionId: number }> {
   const response = await fetch('/wishes', {
     method: 'POST',

--- a/src/components/NoWishes.tsx
+++ b/src/components/NoWishes.tsx
@@ -1,0 +1,10 @@
+export default function NoWishes() {
+  return (
+    <article className="flex h-full flex-col items-center justify-center gap-1">
+      <p className="text-md font-regular leading-xs text-gray-1a">찜해놓은 전시회가 없습니다.</p>
+      <p className="text-md font-regular leading-xs text-gray-aa">
+        맘에 드는 전시회가 있다면 찜해보세요
+      </p>
+    </article>
+  );
+}

--- a/src/components/exhibition-list.tsx
+++ b/src/components/exhibition-list.tsx
@@ -6,7 +6,7 @@ export default function ExhibitionList() {
 
   // TODO: handle when length === 0
   return (
-    <ul className="flex flex-col gap-2 p-2">
+    <ul className="flex h-full flex-col gap-2 overflow-y-auto p-2">
       {exhibitions?.map((exhibition) => (
         <li key={exhibition.id} className="contents">
           <ExhibitionCard exhibition={exhibition} />

--- a/src/components/provider.tsx
+++ b/src/components/provider.tsx
@@ -7,7 +7,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       throwOnError: true,
-      refetchOnMount: false,
+      refetchOnMount: true,
       refetchOnWindowFocus: false,
       refetchIntervalInBackground: false,
     },

--- a/src/components/wish-card.tsx
+++ b/src/components/wish-card.tsx
@@ -1,0 +1,73 @@
+import { Link } from 'react-router-dom';
+
+import StarIconFilled from '@/assets/icon-star-filled.svg';
+import StarIconOutlined from '@/assets/icon-star-outlined.svg';
+import { useAddWishMutation, useDeleteWishMutation } from '@/hooks/useExhibition';
+import type { Exhibition } from '@/types/exhibition-type';
+
+type ExhibitionCardProps = {
+  exhibition: Exhibition;
+};
+
+// TODO: refactor to composition component
+export default function WishCard({ exhibition }: ExhibitionCardProps) {
+  const {
+    id: exhibitionId,
+    title,
+    imageUrl,
+    place,
+    price,
+    isWished,
+    date: { started, ended },
+  } = exhibition;
+
+  const { addWish } = useAddWishMutation();
+  const { deleteWish } = useDeleteWishMutation();
+
+  async function handleClickWish() {
+    isWished ? deleteWish(exhibitionId) : addWish(exhibitionId);
+  }
+
+  return (
+    <div className="flex gap-[10px]">
+      <img src={imageUrl} alt={title} className="size-20 rounded object-cover" />
+      <div className="relative flex flex-grow">
+        <dl className="flex flex-grow flex-col justify-between">
+          <div className="flex flex-col gap-[2px]">
+            <dt className="sr-only">전시회 이름</dt>
+            <dd className="text-md font-bold leading-xs text-gray-1a">{title}</dd>
+
+            <dt className="sr-only">장소</dt>
+            <dd className="text-sm font-regular leading-xs text-gray-99">{place}</dd>
+
+            <dt className="sr-only">가격</dt>
+            <dd className="text-sm font-semibold leading-xs text-orange">{price}원</dd>
+          </div>
+          <div className="absolute bottom-0 right-0">
+            <dt className="sr-only">전시 기간</dt>
+            <dd className="text-xs leading-xs text-gray-3f">
+              {started} ~ {ended}
+            </dd>
+          </div>
+        </dl>
+
+        <button
+          onClick={handleClickWish}
+          className="absolute right-0 top-0 text-sm font-semibold text-orange"
+        >
+          {isWished ? (
+            <img src={StarIconFilled} alt="찜 취소하기" />
+          ) : (
+            <img src={StarIconOutlined} alt="찜 하기" />
+          )}
+        </button>
+        <Link
+          to={`/ticketing/${exhibitionId}`}
+          className="leading-none absolute bottom-0 left-0 flex h-4 w-10 items-center justify-center rounded-sm bg-gray-1a text-xs font-regular text-white"
+        >
+          예매하기
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/wishlist.tsx
+++ b/src/components/wishlist.tsx
@@ -1,0 +1,20 @@
+import { useGetWishesQuery } from '@/hooks/useExhibition';
+
+import ExhibitionCard from './exhibition-card';
+import NoWishes from './NoWishes';
+
+export default function Wishlist() {
+  const wishes = useGetWishesQuery();
+
+  return wishes?.length === 0 ? (
+    <NoWishes />
+  ) : (
+    <ul className="flex flex-col gap-2 p-2">
+      {wishes?.map((wish) => (
+        <li key={wish.id} className="contents">
+          <ExhibitionCard exhibition={wish} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/wishlist.tsx
+++ b/src/components/wishlist.tsx
@@ -1,7 +1,7 @@
 import { useGetWishesQuery } from '@/hooks/useExhibition';
 
-import ExhibitionCard from './exhibition-card';
 import NoWishes from './NoWishes';
+import WishCard from './wish-card';
 
 export default function Wishlist() {
   const wishes = useGetWishesQuery();
@@ -12,7 +12,7 @@ export default function Wishlist() {
     <ul className="flex flex-col gap-2 p-2">
       {wishes?.map((wish) => (
         <li key={wish.id} className="contents">
-          <ExhibitionCard exhibition={wish} />
+          <WishCard exhibition={wish} />
         </li>
       ))}
     </ul>

--- a/src/hooks/useExhibition.ts
+++ b/src/hooks/useExhibition.ts
@@ -1,19 +1,29 @@
-import { useMutation, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 
 import { getExhibitions } from '@/apis/exhibition';
-import { addWish, deleteWish } from '@/apis/wish';
+import { addWish, deleteWish, getWishes } from '@/apis/wish';
 
 const exhibitionQuerykey = {
   all: () => ['exhibitions'],
+  wishes: () => ['wishes'],
 } as const;
 
 export function useExhibition() {
-  const { data: exhibitions } = useSuspenseQuery({
+  const { data: exhibitions } = useQuery({
     queryKey: exhibitionQuerykey.all(),
     queryFn: getExhibitions,
   });
 
   return exhibitions;
+}
+
+export function useGetWishesQuery() {
+  const { data: wishes } = useQuery({
+    queryKey: exhibitionQuerykey.wishes(),
+    queryFn: getWishes,
+  });
+
+  return wishes;
 }
 
 export function useAddWishMutation() {
@@ -23,6 +33,7 @@ export function useAddWishMutation() {
     mutationFn: addWish,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: exhibitionQuerykey.all() });
+      queryClient.invalidateQueries({ queryKey: exhibitionQuerykey.wishes() });
     },
   });
 
@@ -36,6 +47,7 @@ export function useDeleteWishMutation() {
     mutationFn: deleteWish,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: exhibitionQuerykey.all() });
+      queryClient.invalidateQueries({ queryKey: exhibitionQuerykey.wishes() });
     },
   });
 

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -11,7 +11,7 @@ export default function HomePage() {
         <h1 className="sr-only">전시회 목록</h1>
       </header>
 
-      <main>
+      <main className="h-full pb-20">
         <ExhibitionList />
       </main>
 

--- a/src/pages/wishlist-page.tsx
+++ b/src/pages/wishlist-page.tsx
@@ -1,3 +1,50 @@
+import { NavLink } from 'react-router-dom';
+
+import StarIconFilled from '@/assets/icon-star-filled.svg';
+import TicketIcon from '@/assets/icon-ticket-filled.svg';
+import Wishlist from '@/components/wishlist';
+
 export default function WishlistPage() {
-  return <div></div>;
+  return (
+    <>
+      <header>
+        <h1 className="sr-only">찜목록</h1>
+      </header>
+
+      <main className="h-full pb-20">
+        <Wishlist />
+      </main>
+
+      <footer className="shadow-1/2 absolute bottom-0 h-20 w-full pt-px shadow-gray-f4">
+        <nav className="contents">
+          <ul className="flex h-full">
+            <li className="h-full flex-grow p-3">
+              <NavLink
+                to="/"
+                className={({ isActive }) =>
+                  (isActive ? 'text-gray-1a' : 'text-gray-aa') +
+                  ' flex h-full w-full flex-col items-center justify-center gap-1 text-sm font-regular leading-xs'
+                }
+              >
+                <img src={TicketIcon} alt="" />
+                전시회
+              </NavLink>
+            </li>
+            <li className="flex-grow p-3">
+              <NavLink
+                to="/wishlist"
+                className={({ isActive }) =>
+                  (isActive ? 'text-gray-1a' : 'text-gray-aa') +
+                  ' flex h-full w-full flex-col items-center justify-center gap-1 text-sm font-regular leading-xs'
+                }
+              >
+                <img src={StarIconFilled} alt="" />
+                찜목록
+              </NavLink>
+            </li>
+          </ul>
+        </nav>
+      </footer>
+    </>
+  );
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Layout from '@/components/layout';
 import HomePage from '@/pages/home-page';
 import TicketingPage from '@/pages/ticketing-page';
+import WishlistPage from '@/pages/wishlist-page';
 
 function Router() {
   return (
@@ -10,6 +11,7 @@ function Router() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route path="/" element={<HomePage />} />
+          <Route path="/wishlist" element={<WishlistPage />} />
           <Route path="/ticketing/:exhibitionId" element={<TicketingPage />} />
         </Route>
       </Routes>

--- a/src/server/handlers/wishes.ts
+++ b/src/server/handlers/wishes.ts
@@ -1,6 +1,10 @@
 import { http, HttpResponse } from 'msw';
 
-import type { Wish } from '@/types/exhibition-type';
+import type { Exhibition, Wish } from '@/types/exhibition-type';
+
+import { exhibitions } from '../db';
+
+type GetWishResponseBody = Array<Exhibition>;
 
 type AddWishParams = {};
 type AddWishRequestBody = { exhibitionId: number };
@@ -12,6 +16,15 @@ type DeleteWishResponseBody = { deletedExhibitionId: number };
 
 // TODO: change route to /user/me/wishes
 export const handlers = [
+  http.get<{}, {}, GetWishResponseBody, '/user/me/wishes'>('/user/me/wishes', () => {
+    const wishesData = JSON.parse(localStorage.getItem('wishes') || '[]') as Array<Wish>;
+    const wishes = exhibitions
+      .filter((exhibition) => wishesData.includes(exhibition.id))
+      .map((wish) => ({ ...wish, isWished: true }));
+
+    return HttpResponse.json(wishes);
+  }),
+
   http.post<AddWishParams, AddWishRequestBody, AddWishResponseBody, '/wishes'>(
     '/wishes',
     async ({ request }) => {
@@ -25,6 +38,7 @@ export const handlers = [
       return HttpResponse.json({ wishedExhibitionId: exhibitionId });
     },
   ),
+
   http.delete<DeleteWishParams, DeleteWishRequestBody, DeleteWishResponseBody, '/wishes'>(
     '/wishes',
     async ({ request }) => {


### PR DESCRIPTION
## `user/me/wishes`
- 찜목록을 불러오는 API 엔드포인트를 `user/me/wishes`로 지정했다.
- 특정 사용자의 찜목록을 불러오는 것이므로 `/wishes`보다 사용자와 찜목록의 관계를 잘 나타낸다고 판단했다.
- `/me` : 일반적으로 특정 게시글의 댓글 목록을 불러온다면, `/posts/3424/comments`라는 URI로 요청을 보낼 것이다. 하지만 사용자의 찜목록을 불러오는 URI에 `/users/8023984/wishes`와 같이 사용자의 식별자가 드러나면 보안 취약점이 될 거라고 판단했다.

## `refetchOnMount: true`
#### 문제
- `inactive` 상태의 특정 쿼리를 `invalidate`한 뒤, 해당 쿼리가 마운트되어 `active` 상태로 전환되었을 때 `refetch`가 되어야 하는데 되지 않았다.
#### 원인
- 네트워크 요청을 최대한 줄이고자 `queryClient`의 기본 옵션 중 `refetchOnMount`을 `false`로 설정해 놓은 것이 원인이었다.
#### 해결
- `refetchOnMount: true`로 변경했다.

## `refetchType: "active"`
#### 문제
- 전시회 목록 화면에서 전시회를 찜 또는 취소한 뒤, 찜목록 화면으로 이동하면 찜목록 컴포넌트가 한 번 깜빡이는 현상이 있었다.
#### 원인
- 전시회를 찜하는 `mutation`이 성공하면 `invalidateQueries(["wishes"])`로 찜목록의 쿼리를 무효화하는 식으로 구현해 놓았다.
- 이때 `invalidateQueries`의 `refetchType` 옵션의 기본값은 `active`로, 이는 `active`상태인 쿼리만 `refetch`하게 하는 옵션이다.
- 그래서 전시회 목록 화면에서 찜목록의 쿼리는 `inactive` 상태이므로 `refetch`되지 않고, 찜목록 화면에 진입해 찜목록 쿼리가 `active` 상태가 된 후에 `refetch`되었고, 변경된 데이터에 맞춰 리렌더링이 일어나 깜빡였던 것이다.
#### 결정
- `invalidateQuries`의 `refetchType` 옵션을 `all` 또는 `inactive`로 변경하면 깜빡임을 없앨 수 있었다.
- 하지만 이 방식은 `mutation`이 발생할 때마다 백그라운드에서 `refetch` 하므로 네트워크 요청 횟수의 총량이 늘어나며, 지금은 데이터 수가 적어서 괜찮지만 사용자 수가 많아지면 성능에 문제가 될 수도 있다고 판단했다.
- 그러므로 백그라운드 `refetch` N번 vs 찜목록 진입시 `refetch` 1번 중 후자를 선택했다.

## TODO: `같은 데이터, 다른 스타일의 컴포넌트`
- 전시회 목록의 카드와 찜목록의 카드가 표시하는 데이터는 완전히 동일하며, 전시일자와 예매하기 버튼의 위치만 다르다.
- 이에 더해 앞으로 구현할 예매 페이지에서도, 표시되는 전시회의 정보는 동일하며 스타일만 다르다.
- 이렇게 데이터가 동일하고 스타일만 다른 컴포넌트가 지금은 3개이지만 앞으로 더 생길 수도 있고, 이후에 스타일 변경 요청이 들어올 수도 있으니 전시회 정보를 받아 렌더링만 하고 스타일은 입히지 않은 헤드리스 합성 컴포넌트를 만드는 게 좋을 것 같다.

close #5 